### PR TITLE
Don't dereference data when undefined

### DIFF
--- a/chart-property-mixin.js
+++ b/chart-property-mixin.js
@@ -66,6 +66,7 @@ export const ChartPropertyMixin = function(superClass) {
     }
 
     _configurationChanged(data) {
+      if (!data) return;
       if ((this.__type === 'bubble' || data.labels) && data.datasets) {
         this.__hasData = true;
       } else {


### PR DESCRIPTION
This allows loading the chart before data is defined, e.g. when using
dynamic data from the network. Previously, it would reference
data.labels and throw an error.

Everything else is working great, thanks for the lit-html port :)